### PR TITLE
clean up logging

### DIFF
--- a/server/admin/etl/pentaho/pentaho.py
+++ b/server/admin/etl/pentaho/pentaho.py
@@ -181,7 +181,7 @@ class CarteController:
             if response.status_code == 200:
                 return response.content
         except requests.exceptions.ConnectionError as e:
-            logger.warning(e)
+            logger.warning(e, exc_info=True)
         return False
 
     def stop(self):
@@ -523,6 +523,6 @@ class CarteController:
                 responses.append(start_response.content)
             except CarteControllerLoadJobsError as e:
                 #if one Job fails to load, log it & try next job
-                logger.error(e)
+                logger.info(e, exc_info=True)
                 continue
         return responses

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -156,7 +156,7 @@ def wrap_app_with_session_middleware(wsgi_app):
         engine.execute(cleanup_sql, [delete_older_than_modifier])
     except Exception as e:
         # but dont worry, cleanup will be retried next time WSGI app launches
-        logger.error(e)
+        logger.info(e, exc_info=True)
         # ignore error, & continue
     # install the session middleware!
     return SessionMiddleware(wsgi_app, session_opts)
@@ -176,9 +176,9 @@ def start_etl_scheduler():
         pentaho_started = True
     except TypeError as e:
         startup_exception = Exception('Failed to start Carte etl-scheduler', e) #TODO: define custom class
-        logging.warning(startup_exception, stack_info=True)
+        logging.warning(startup_exception, exc_info=True)
     except pentaho.CarteControllerTempdirPrefixStarted as e:
-        logging.warning(e, stack_info=True)
+        logging.warning(e, exc_info=True)
 
 def get_uri_template(resource_path):
     """

--- a/server/api/resources/source/csw/csw.py
+++ b/server/api/resources/source/csw/csw.py
@@ -98,7 +98,7 @@ def update_csw_repo():
     except TempRepoLocked as e:
         msg = "Skipping CSW repo update, an update is already in-progress"
         logger.warning(msg)
-        logger.debug(e.__cause__, stack_info=True)
+        logger.debug(e.__cause__, exc_info=True)
     # schedule the next update
     schedule_update()
 

--- a/server/api/resources/source/data/util.py
+++ b/server/api/resources/source/data/util.py
@@ -40,7 +40,7 @@ def get_engine_from_config(api_config_file_name):
         db_config['sqlalchemy.url'] = str(db_url)
     except TypeError as e:
         exception = ConfigPasswordCiphertextError(api_config_file_name, e)
-        logging.error(exception, stack_info=True)
+        logging.info(exception, exc_info=True)
     # instantiate engine from config
     engine = sqlalchemy.engine_from_config(db_config)
     return engine

--- a/server/api/resources/source/variables.py
+++ b/server/api/resources/source/variables.py
@@ -70,7 +70,7 @@ class Variables:
                 dwsupport_variables = get_list_of_variables( str_dataset_id)
             except NotImplementedError as e:
                 #error; not a warehouse request & Dataset does not match requested ID
-                logging.error( e)
+                logging.exception(e)
                 raise falcon.HTTPError(falcon.HTTP_NOT_IMPLEMENTED, 'Not Implemented', str(e))
             # format the DWSupport info, for publishing
             tables, associations = model['tables'], model['associations']

--- a/server/api/resources/source/warehouse/support/dto/variable.py
+++ b/server/api/resources/source/warehouse/support/dto/variable.py
@@ -213,7 +213,7 @@ def get_by_lookup(table_names, db_url=None, connection_func=None):
                     python_type = variable_python_type.get_by_lookup( table, column
                                                     ,db_url, connection_func)
                 except variable_python_type.LookupNullType as e:
-                    logging.error( e)
+                    logging.info(e, exc_info=True)
                     continue #skip this table field
                 variable = {'table': table,'column': column
                             ,'title': None, 'description': None

--- a/server/api/resources/source/warehouse/support/dto_util.py
+++ b/server/api/resources/source/warehouse/support/dto_util.py
@@ -213,7 +213,7 @@ def get_roles( associations):
                 bad = table_association
                 unparseable_role_associations.append( bad)
                 msg = "unable to determine Role name for association: {}"
-                logging.error( DimensionRoleError(msg.format(bad)))
+                logging.info(DimensionRoleError(msg.format(bad)), exc_info=True)
                 continue #skip further processing of the association
             # make new name for role, using the prefix
             role_name = role_prefix + parent_table

--- a/server/api/resources/source/warehouse/support/model/prefetch_cache.py
+++ b/server/api/resources/source/warehouse/support/model/prefetch_cache.py
@@ -142,7 +142,7 @@ class Controller():
         try:
             self._cache_data()
         except Exception as e:
-            self.logger.error(e)
+            self.logger.info(e, exc_info=True)
         # assign a new task to the module-level thread variable
         self._update_thread = threading.Timer(self._poll_interval_seconds
                                         ,self._fetch_and_schedule_update)


### PR DESCRIPTION
Normalized server logging to:
- use exception() when handling an error
- use non-ERROR loglevel + `exc_info` for non-error informative messages
- if log line must be short/single-line then skip `exc_info`
- use `stack_info` only if logging outside of an except handler